### PR TITLE
Pass message limit down when creating room in one-to-one HOC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@ This project adheres to [Semantic Versioning Scheme](http://semver.org)
 ---
 
 ## [Unreleased](https://github.com/pusher/chatkit-client-react/compare/0.1.0...HEAD)
+### Additions
+
+- Add `messageLimit` property to the withChatkitOneToOne HOC

--- a/src/with-chatkit-one-to-one.js
+++ b/src/with-chatkit-one-to-one.js
@@ -46,6 +46,8 @@ export function withChatkitOneToOne(WrappedComponent) {
       this._currentUserId = null
       this._otherUserId = props.otherUserId
 
+      this._messageLimitOnLoad = props.messageLimit
+
       this._roomId = null
       this._currentUserLastReadMessageId = null
     }
@@ -112,6 +114,7 @@ export function withChatkitOneToOne(WrappedComponent) {
           .then(() =>
             this.context.chatkit.currentUser.subscribeToRoomMultipart({
               roomId: this._roomId,
+              messageLimit: this._messageLimitOnLoad,
               hooks: {
                 onMessage: message =>
                   this.setState(state => ({

--- a/src/with-chatkit-one-to-one.js
+++ b/src/with-chatkit-one-to-one.js
@@ -206,6 +206,7 @@ export function withChatkitOneToOne(WrappedComponent) {
   )})`
   WithChatkitOneToOne.propTypes = {
     otherUserId: PropTypes.string.isRequired,
+    messageLimit: PropTypes.number,
   }
 
   return WithChatkitOneToOne


### PR DESCRIPTION
Customers have raised the concern that they cannot configure the message limit on initial load with this SDK.

This PR passes the parameter down to the underlying Chatkit JS SDK.